### PR TITLE
fix: perbaiki metadata lisensi proyek pada package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "author": "dhafitf",
-  "license": "ISC",
+  "license": "GPL-3.0-only",
   "dependencies": {
     "@discordjs/builders": "^0.11.0",
     "@discordjs/rest": "^0.2.0-canary.0",


### PR DESCRIPTION
Kode sumber repo saat ini dinyatakan berlisensi GNU General Public License versi 3.0, sedangkan kolom "license" pada package.json masih mengarah kepada ISC (Internet Systems Consortium, default untuk perintah `npm init`).

Commit ini memperbaikinya agar sesuai dengan jenis lisensi proyek yang diinginkan.